### PR TITLE
dev

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,11 +5,15 @@
 import FlutterMacOS
 import Foundation
 
+import firebase_core
+import firebase_messaging
 import path_provider_foundation
 import shared_preferences_foundation
 import sqlite3_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "72.0.0"
+  _flutterfire_internals:
+    dependency: transitive
+    description:
+      name: _flutterfire_internals
+      sha256: "5a0296da7ae717ffb7444dee8439ca25ac80e162a345b933aa57f0a4a48dca2c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.45"
   _macros:
     dependency: transitive
     description: dart
@@ -254,6 +262,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  firebase_core:
+    dependency: transitive
+    description:
+      name: firebase_core
+      sha256: e59141ff83e70a9ba571a1f8733c5598cf57e6e68037ab185581d7fc0a436738
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.7.0"
+  firebase_core_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_core_platform_interface
+      sha256: e30da58198a6d4b49d5bce4e852f985c32cb10db329ebef9473db2b9f09ce810
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.3.0"
+  firebase_core_web:
+    dependency: transitive
+    description:
+      name: firebase_core_web
+      sha256: f967a7138f5d2ffb1ce15950e2a382924239eaa521150a8f144af34e68b3b3e5
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.18.1"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: a988c6ab37fa5a6abf2f8087a44b765e058848ace6f3253fb1602d1d44a63747
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.1.4"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "66aa477277baf2430904096234dd2095ad2e0248d0bfefc1b11695e68bf1790e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.47"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: "8b590d8c421dc4f63a28c6b9690a050424c28b99a54886ded4510c0806237130"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.9.3"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   sqlite3: ^2.4.6
   xdg_directories: ^1.1.0
   protobuf: ^3.1.0
+  firebase_messaging: ^15.1.4
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <firebase_core/firebase_core_plugin_c_api.h>
 #include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FirebaseCorePluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   Sqlite3FlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  firebase_core
   sqlite3_flutter_libs
 )
 


### PR DESCRIPTION
- **Revert "Remove x3dh.rs"**
- **Add recipes for building and precommit.**
- **Add instructions for Android build.**
- **Fix Android Build**
- **Justfile tabs + thought out build/precommit.**
- **Fix android + server nix build**
- **Justfile precommit fix dart command.**
- **Create ClientError instead of returning anyhow.**
- **Add format shortcut.**
- **Local running server uses XDG data directory.**
- **Decryption failures does not terminate message stream.**
- **Simplify flutter rust layer.**
- **DEBUG print messages.**
- **Flutter apps can message each other.**
- **Remove example flutter widget test.**
- **Add a glossary.**
- **Return error on verify bundle failure.**
- **Replace {e,}println! with tracing**
- **Flutter Deprecation: replace background with surface.**
- **flutter pub add protobuf**
- **MaterialStatePropertyAll -> WidgetStatePropertyAll**
- **Set server log level to debug for now.**
- **Limit #[allow(deprecated)] to base64 call and properly log opk public key.**
- **Use https url in flutter.**
- **Ignore dart lint error for unused _db.**
- **Fix linter suggestions.**
- **Add sentry.**
- **Async Sqlite.**
